### PR TITLE
Bugfix - add dropdown for price quote

### DIFF
--- a/src/views/bonds/BondsForm.js
+++ b/src/views/bonds/BondsForm.js
@@ -258,9 +258,14 @@ function BondsForm(props) {
             id="price_quote"
             name="price_quote"
             placeholder="Price quote"
-            type="price_quote"
+            type="select"
             onChange={(e) => setPrice_quote(e.target.value)}
-          />
+          >
+            <option value="">Select type</option>
+            <option value="PAR">PAR</option>
+            <option value="DISCOUNTED">DISCOUNTED</option>
+            <option value="PREMIUM">PREMIUM</option>
+          </Input>
         </FormGroup>
         <FormGroup>
           <Label for="dirty_price">Dirty price</Label>


### PR DESCRIPTION
The bond create/edit form did not have the price quote select options, this change fixes that issue