### PR TITLE
Add support for bond sale period

### DIFF
--- a/src/_nav.js
+++ b/src/_nav.js
@@ -1,38 +1,50 @@
 import React from 'react'
 import CIcon from '@coreui/icons-react'
-import { cilMoney, cilSpeedometer } from '@coreui/icons'
-import { CNavGroup, CNavItem } from '@coreui/react'
+import { cilBank, cilChartLine, cilUser } from '@coreui/icons'
+import { CNavItem } from '@coreui/react'
 
 const _nav = [
   {
     component: CNavItem,
     name: 'Dashboard',
     to: '/dashboard',
-    icon: <CIcon icon={cilSpeedometer} customClassName="nav-icon" />,
+    icon: <CIcon icon={cilChartLine} customClassName="nav-icon" />,
   },
   {
-    component: CNavGroup,
+    component: CNavItem,
     name: 'Bonds',
-    to: '/bonds',
-    icon: <CIcon icon={cilMoney} customClassName="nav-icon" />,
-    items: [
-      {
-        component: CNavItem,
-        name: 'All bonds',
-        to: '/bonds/all_bonds',
-      },
-      {
-        component: CNavItem,
-        name: 'Bonds on sale',
-        to: '/bonds/open',
-      },
-      {
-        component: CNavItem,
-        name: 'My bonds',
-        to: '/bonds/my_bonds',
-      },
-    ],
+    to: '/bonds/all_bonds',
+    icon: <CIcon icon={cilBank} customClassName="nav-icon" />,
   },
+  {
+    component: CNavItem,
+    name: 'My Bonds',
+    to: '/bonds/my_bonds',
+    icon: <CIcon icon={cilUser} customClassName="nav-icon" />,
+  },
+  // {
+  //   component: CNavGroup,
+  //   name: 'Bonds',
+  //   to: '/bonds',
+  //   icon: <CIcon icon={cilMoney} customClassName="nav-icon" />,
+  //   items: [
+  //     {
+  //       component: CNavItem,
+  //       name: 'All bonds',
+  //       to: '/bonds/all_bonds',
+  //     },
+  //     {
+  //       component: CNavItem,
+  //       name: 'Bonds on sale',
+  //       to: '/bonds/open',
+  //     },
+  //     {
+  //       component: CNavItem,
+  //       name: 'My bonds',
+  //       to: '/bonds/my_bonds',
+  //     },
+  //   ],
+  // },
 ]
 
 export default _nav

--- a/src/views/bonds/BondsForm.js
+++ b/src/views/bonds/BondsForm.js
@@ -20,6 +20,8 @@ function BondsForm(props) {
   const [maturity, setMaturity] = useState(props.maturity)
   const [price_quote, setPrice_quote] = useState(props.price_quote)
   const [dirty_price, setDirty_price] = useState(props.dirty_price)
+  const [sale_date_start, setSale_date_start] = useState(props.sale_date_start)
+  const [sale_date_end, setSale_date_end] = useState(props.sale_date_end)
   const [id] = useState(props.id)
 
   const handleSubmit = async (e) => {
@@ -38,6 +40,8 @@ function BondsForm(props) {
       maturity,
       price_quote,
       dirty_price,
+      sale_date_start,
+      sale_date_end,
     }
 
     const onSuccess = ({ data }) => {
@@ -85,6 +89,8 @@ function BondsForm(props) {
       maturity,
       price_quote,
       dirty_price,
+      sale_date_start,
+      sale_date_end,
     }
 
     const onSuccess = ({ data }) => {
@@ -208,6 +214,28 @@ function BondsForm(props) {
           />
         </FormGroup>
         <FormGroup>
+          <Label for="sale_date_start">Sale start date</Label>
+          <Input
+            defaultValue={sale_date_start}
+            id="sale_date_start"
+            name="sale_date_start"
+            placeholder="Sale start date"
+            type="date"
+            onChange={(e) => setSale_date_start(e.target.value)}
+          />
+        </FormGroup>
+        <FormGroup>
+          <Label for="sale_date_end">Sale end date</Label>
+          <Input
+            defaultValue={sale_date_end}
+            id="sale_date_end"
+            name="sale_date_end"
+            placeholder="Sale end date"
+            type="date"
+            onChange={(e) => setSale_date_end(e.target.value)}
+          />
+        </FormGroup>
+        <FormGroup>
           <Label for="coupon_rate">Coupon rate</Label>
           <Input
             defaultValue={coupon_rate}
@@ -303,6 +331,8 @@ BondsForm.propTypes = {
   maturity: PropTypes.number,
   price_quote: PropTypes.string,
   dirty_price: PropTypes.number,
+  sale_date_start: PropTypes.string,
+  sale_date_end: PropTypes.string,
   id: PropTypes.string,
 }
 

--- a/src/views/bonds/BondsTable.js
+++ b/src/views/bonds/BondsTable.js
@@ -72,6 +72,8 @@ export default function BondsTable(props) {
       tenor: bond.tenor,
       maturity: bond.maturity,
       coupon_payment_dates: bond.coupon_payment_dates,
+      sale_date_start: bond.sale_date_start,
+      sale_date_end: bond.sale_date_end,
     })
   })
 

--- a/src/views/bonds/BondsTable.js
+++ b/src/views/bonds/BondsTable.js
@@ -36,13 +36,14 @@ export default function BondsTable(props) {
     { field: 'issue', headerName: 'Issue', flex: 1, minWidth: 130 },
     { field: 'issuer', headerName: 'Issuer', flex: 1.5, minWidth: 200 },
     { field: 'type', headerName: 'Type', flex: 1, minWidth: 130 },
+    { field: 'onsale', headerName: 'On Sale', flex: 1, minWidth: 130 },
     { field: 'value_date', headerName: 'Value Date', flex: 1, minWidth: 130 },
     { field: 'redemption_date', headerName: 'Redemption Date', flex: 1, minWidth: 130 },
     { field: 'amount', headerName: 'Amount', flex: 1, minWidth: 130 },
     { field: 'coupon_rate', headerName: 'Coupon Rate', flex: 1, minWidth: 100 },
     { field: 'tax_rate', headerName: 'Tax Rate', flex: 1, minWidth: 70 },
     { field: 'tenor', headerName: 'Tenor', flex: 1, minWidth: 70 },
-    { field: 'maturity', headerName: 'Time to Maturity', flex: 1, minWidth: 100 },
+    { field: 'maturity', headerName: 'Maturity', flex: 1, minWidth: 100 },
     {
       field: 'action',
       headerName: 'Action',
@@ -50,6 +51,22 @@ export default function BondsTable(props) {
       renderCell: renderDetailsButton,
     },
   ]
+
+  const isBondOnSale = (startDate, endDate) => {
+    if (startDate === null || endDate === null) {
+      return false
+    }
+
+    startDate = new Date(startDate)
+    endDate = new Date(endDate)
+    var today = new Date()
+
+    if (today >= startDate && today <= endDate) {
+      return true
+    }
+
+    return false
+  }
 
   const bonds = Array.from(props.bonds)
 
@@ -60,6 +77,7 @@ export default function BondsTable(props) {
       id: bond.uid,
       issue: bond.issue,
       issuer: bond.issuer,
+      onsale: isBondOnSale(bond.sale_date_start, bond.sale_date_end) === true ? 'Open' : 'Closed',
       type: bond.type,
       price_quote: bond.price_quote,
       value_date: bond.value_date,


### PR DESCRIPTION
To know which bonds are currently on sale, we need to cater for the period of sale in bond prospectuses. 