### PR TITLE
coupon-rate #52

### DIFF
--- a/src/views/bonds/BondsForm.js
+++ b/src/views/bonds/BondsForm.js
@@ -243,7 +243,7 @@ function BondsForm(props) {
             name="coupon_rate"
             placeholder="Coupon rate"
             type="number"
-            step="0.01"
+            step="0.001"
             onChange={(e) => setCoupon_rate(e.target.value)}
           />
         </FormGroup>

--- a/src/views/bonds/BondsForm.js
+++ b/src/views/bonds/BondsForm.js
@@ -243,6 +243,7 @@ function BondsForm(props) {
             name="coupon_rate"
             placeholder="Coupon rate"
             type="number"
+            step="0.01"
             onChange={(e) => setCoupon_rate(e.target.value)}
           />
         </FormGroup>


### PR DESCRIPTION
 Fixed Bug - coupon rate field in bond creation form does not accept decimal place. #52